### PR TITLE
Week4

### DIFF
--- a/records/4Week_김민우.md
+++ b/records/4Week_김민우.md
@@ -1,0 +1,40 @@
+## Title: [4Week] 김민우
+
+### 미션 요구사항 분석 & 체크리스트
+
+필수미션
+* [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
+* [x] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용
+
+<br>
+
+선택미션 
+* [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
+* [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
+  * [x] 최신순: 최근에 받은 호감부터 보여준다.
+  * [x] 날짜순: 가장 오래전에 받은 호감부터 보여준다.
+  * [x] 인기 많은 순서: 나에게 호감을 표하는 사람들의 인기를 기준으로 정렬한다.
+  * [x] 인기 적은 순서: 나에게 호감을 표하는 사람들의 인기를 기준으로 정렬한다.
+  * [x] 성별순: 여성부터 표기하고 그 다음에 남성 표기. 2순위 정렬조건은 최신
+  * [x] 호감사유: 외모->성격->능력 순서로 리스트를 정렬한다.
+* [ ] 젠킨스를 통해서 repository 의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포되로고 하기.
+
+### 4주차 미션 요약
+
+---
+
+**[접근 방법]**
+
+1. 필터링 기능 + 정렬 기능
+* stream 의 filter()를 이용해서 List<LikeablePerson> 을 gender, attractiveTypeCode 2개를 기준으로 필터링을 했다.
+* 정렬 기능도 마찬가지로 stream 을 사용했다. stream 의 sorted() 와 정렬의 기준으로 세우는 Comparator.comparing()을 사용했다.
+  * 정렬 기준이 2가지 이상인 경우에는 `Comparator.comparing(1차 정렬 조건).thenComparing(2차 정렬 조건)` 이렇게 사용했다.
+
+
+
+**[특이사항]**
+* stream 을 이용해서 정렬을 하였는데, 인기를 기준으로 정렬을 하는데 조금 어려웠다.
+* likeablePerson.getFromInstaMember().getToLikeablePeople().size() 로 비교를 해야되는데 계속 에러가 발생했다.
+* 에러의 원인은 chatGPT 에게 물어봤더니, getToLikeablePeople() or getFromInstaMember() 에게 null 을 반환할 수 있기 때문이였다.
+
+**참고: [Refactoring]**

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -57,6 +57,12 @@ public class NotProd {
                 instaMemberService.connect(memberUser4, "insta_user4", "M");
                 instaMemberService.connect(memberUser5, "insta_user5", "W");
 
+                instaMemberService.connect(memberUser6ByKakao, "insta_user6", "M");
+                instaMemberService.connect(memberUser7ByGoogle, "insta_user7", "W");
+                instaMemberService.connect(memberUser8ByNaver, "insta_user8", "M");
+                instaMemberService.connect(memberUser9ByFacebook, "insta_user9", "W");
+
+
                 // 원활한 테스트와 개발을 위해서 자동으로 만들어지는 호감이 삭제, 수정이 가능하도록 쿨타임해제
                 LikeablePerson likeablePersonToInstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
                 Ut.reflection.setFieldValue(likeablePersonToInstaUser4, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
@@ -64,6 +70,13 @@ public class NotProd {
                 Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
 
                 LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+                LikeablePerson likeablePersonToInstaUser5 = likeablePersonService.like(memberUser2, "insta_user5", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_2 = likeablePersonService.like(memberUser2, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_3 = likeablePersonService.like(memberUser5, "insta_user4", 3).getData();
+                LikeablePerson likeablePersonToInstaUser4_4 = likeablePersonService.like(memberUser6ByKakao, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_5 = likeablePersonService.like(memberUser7ByGoogle, "insta_user4", 1).getData();
+                LikeablePerson likeablePersonToInstaUser4_6 = likeablePersonService.like(memberUser8ByNaver, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_7 = likeablePersonService.like(memberUser9ByFacebook, "insta_user4", 3).getData();
             }
         };
     }

--- a/src/main/java/com/ll/gramgram/base/rq/Rq.java
+++ b/src/main/java/com/ll/gramgram/base/rq/Rq.java
@@ -17,9 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 import org.springframework.web.servlet.LocaleResolver;
 
-import java.util.Date;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 @Component
 @RequestScope
@@ -168,5 +166,18 @@ public class Rq {
         Map<String, String[]> parameterMap = req.getParameterMap();
 
         return Ut.json.toStr(parameterMap);
+    }
+
+    public Map<String, String> getAllParams(){
+        Map<String, String> params = new HashMap<>();
+        Enumeration<String> parameterNames = req.getParameterNames();
+        while (parameterNames.hasMoreElements()) {
+            String name = parameterNames.nextElement();
+            String value = req.getParameter(name);
+            params.put(name, value);
+            System.out.println(name +" : " + value);
+        }
+
+        return params;
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -5,6 +5,7 @@ import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Enumeration;
 import java.util.List;
 
 @Controller
@@ -122,13 +124,13 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model) {
+    public String showToList(Model model, HttpServletRequest request) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
-            // 해당 인스타회원이 좋아하는 사람들 목록
-            List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
+            // 해당 인스타회원을 좋아하는 사람들 목록
+            List<LikeablePerson> likeablePeople = likeablePersonService.filteredLikeablePerson(instaMember, rq.getAllParams());
             model.addAttribute("likeablePeople", likeablePeople);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -290,7 +290,16 @@ public class LikeablePersonService {
                         .collect(Collectors.toList());
             }
         }
-
         return toLikeablePeople;
     }
+
+    public List<LikeablePerson> findByToInstaMember(String username, String gender, String attractiveTypeCode, String sortCode) {
+        Map<String, String> params = new HashMap<>();
+        params.put("gender", gender);
+        params.put("attractiveTypeCode", attractiveTypeCode);
+        params.put("sortCode", sortCode);
+        return filteredLikeablePerson(instaMemberService.findByUsername(username).get(), params);
+    }
+
+
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -15,9 +15,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -218,5 +217,76 @@ public class LikeablePersonService {
 
 
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
+    }
+
+    public List<LikeablePerson> filteredLikeablePerson(InstaMember instaMember, Map<String, String> requestParams) {
+        List<LikeablePerson> toLikeablePeople = instaMember.getToLikeablePeople();
+
+        //성별 필터링
+        String gender = (String) requestParams.get("gender");
+        if (gender != null && !gender.equals("")) {
+            toLikeablePeople = toLikeablePeople.stream()
+                    .filter(likeablePerson -> likeablePerson.getFromInstaMember().getGender().equals(gender))
+                    .collect(Collectors.toList());
+        }
+
+        //호감사사유 필터링
+        String attractiveTypeCode = requestParams.get("attractiveTypeCode");
+        if (attractiveTypeCode != null && !attractiveTypeCode.equals("")) {
+            toLikeablePeople = toLikeablePeople.stream()
+                    .filter(likeablePerson -> likeablePerson.getAttractiveTypeCode()==Integer.parseInt(attractiveTypeCode))
+                    .collect(Collectors.toList());
+        }
+
+        //정렬
+        String sortCode = requestParams.get("sortCode");
+        if (sortCode != null && !sortCode.equals("")) {
+            //1 - 날짜(내림차순) - 최신
+            //2 - 날짜(오름차순) - 오래 된 것부터
+            //3 - 호감을 표한 사람을 기준으로 인기 많은 순서
+            //4 - 호감을 표한 사람을 기준으로 인기 적은 순서
+            //5 - 성별(여성 -> 남자)
+            //6 - 호감사유 순서(외모 -> 성격 -> 능력)
+            if (sortCode.equals("1")) {
+
+                toLikeablePeople = toLikeablePeople.stream()
+                        .sorted(Comparator.comparing(LikeablePerson::getCreateDate).reversed())
+                        .collect(Collectors.toList());
+            } else if (sortCode.equals("2")) {
+
+                toLikeablePeople = toLikeablePeople.stream()
+                        .sorted(Comparator.comparing(LikeablePerson::getCreateDate))
+                        .collect(Collectors.toList());
+            } else if (sortCode.equals("3")) {
+
+                toLikeablePeople = toLikeablePeople.stream()
+                        .sorted(Comparator.comparing(lp -> lp.getFromInstaMember() == null ? 0 : -lp.getFromInstaMember().getToLikeablePeople().size()))
+                        .collect(Collectors.toList());
+
+            } else if (sortCode.equals("4")) {
+
+                toLikeablePeople = toLikeablePeople.stream()
+                        .sorted(Comparator.comparing(lp -> lp.getFromInstaMember() == null ? 0 : lp.getFromInstaMember().getToLikeablePeople().size()))
+                        .collect(Collectors.toList());
+
+            } else if (sortCode.equals("5")) {
+
+                toLikeablePeople = toLikeablePeople.stream()
+                        .sorted(
+                                Comparator.comparing(LikeablePerson::getFromInstaMember, Comparator.comparing(InstaMember::getGender))
+                                        .thenComparing(LikeablePerson::getCreateDate).reversed()
+                        )
+                        .collect(Collectors.toList());
+
+            } else if (sortCode.equals("6")) {
+
+                toLikeablePeople = toLikeablePeople.stream()
+                        .sorted(Comparator.comparing(LikeablePerson::getAttractiveTypeCode).reversed()
+                                .thenComparing(LikeablePerson::getCreateDate).reversed())
+                        .collect(Collectors.toList());
+            }
+        }
+
+        return toLikeablePeople;
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -258,15 +258,19 @@ public class LikeablePersonService {
                         .sorted(Comparator.comparing(LikeablePerson::getCreateDate))
                         .collect(Collectors.toList());
             } else if (sortCode.equals("3")) {
-
                 toLikeablePeople = toLikeablePeople.stream()
-                        .sorted(Comparator.comparing(lp -> lp.getFromInstaMember() == null ? 0 : -lp.getFromInstaMember().getToLikeablePeople().size()))
+                        .sorted(Comparator.comparing(LikeablePerson::getFromInstaMember,
+                                Comparator.comparing(InstaMember::getLikes)).reversed()
+                                .thenComparing(LikeablePerson::getCreateDate)
+                        )
                         .collect(Collectors.toList());
 
             } else if (sortCode.equals("4")) {
-
                 toLikeablePeople = toLikeablePeople.stream()
-                        .sorted(Comparator.comparing(lp -> lp.getFromInstaMember() == null ? 0 : lp.getFromInstaMember().getToLikeablePeople().size()))
+                        .sorted(Comparator.comparing(LikeablePerson::getFromInstaMember,
+                                Comparator.comparing(InstaMember::getLikes))
+                                .thenComparing(LikeablePerson::getCreateDate)
+                        )
                         .collect(Collectors.toList());
 
             } else if (sortCode.equals("5")) {

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -2,6 +2,7 @@ package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
 import com.ll.gramgram.base.appConfig.AppConfig;
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import com.ll.gramgram.boundedContext.member.entity.Member;
@@ -16,10 +17,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -432,5 +438,91 @@ public class LikeablePersonControllerTests {
                 .andExpect(status().is4xxClientError());
 
         assertThat(likeablePersonService.findById(3L).get().getAttractiveTypeCode()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("남성 필터링")
+    @WithUserDetails("user4")
+    void t018() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/usr/likeablePerson/toList?gender=M"))
+                .andDo(print());
+
+        // THEN
+        MvcResult mvcResult = resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("showToList"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        Map<String, Object> model = mvcResult.getModelAndView().getModel();
+
+        List<LikeablePerson> likeablePeople = (List<LikeablePerson>) model.get("likeablePeople");
+
+        Map<String, Long> countings = likeablePeople
+                .stream()
+                .map(LikeablePerson::getFromInstaMember)
+                .map(InstaMember::getGender)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        assertThat(countings.get("M")).isEqualTo(likeablePeople.size());
+    }
+
+    @Test
+    @DisplayName("여성 필터링")
+    @WithUserDetails("user4")
+    void t019() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/usr/likeablePerson/toList?gender=W"))
+                .andDo(print());
+
+        // THEN
+        MvcResult mvcResult = resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("showToList"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        Map<String, Object> model = mvcResult.getModelAndView().getModel();
+
+        List<LikeablePerson> likeablePeople = (List<LikeablePerson>) model.get("likeablePeople");
+
+        Map<String, Long> countings = likeablePeople
+                .stream()
+                .map(LikeablePerson::getFromInstaMember)
+                .map(InstaMember::getGender)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        assertThat(countings.get("W")).isEqualTo(likeablePeople.size());
+    }
+
+    @Test
+    @DisplayName("외모 필터링")
+    @WithUserDetails("user4")
+    void t020() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/usr/likeablePerson/toList?attractiveTypeCode=1"))
+                .andDo(print());
+
+        // THEN
+        MvcResult mvcResult = resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("showToList"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        Map<String, Object> model = mvcResult.getModelAndView().getModel();
+
+        List<LikeablePerson> likeablePeople = (List<LikeablePerson>) model.get("likeablePeople");
+
+        Map<Integer, Long> countings = likeablePeople
+                .stream()
+                .map(LikeablePerson::getAttractiveTypeCode)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        assertThat(countings.get(1)).isEqualTo(likeablePeople.size());
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -262,5 +264,76 @@ public class LikeablePersonServiceTests {
         assertThat(
                 likeablePersonToBts.getModifyUnlockDate().isAfter(coolTime)
         ).isTrue();
+    }
+
+    @Test
+    @DisplayName("정렬 - 최신순")
+    void t009() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", "0", "1");
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId, Comparator.reverseOrder()));
+    }
+
+    @Test
+    @DisplayName("정렬 - 날짜순")
+    @Rollback(false)
+    void t010() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", "0", "2");
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId));
+    }
+
+    @Test
+    @DisplayName("정렬 - 인기 많은 순")
+    @Rollback(false)
+    void t011() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", "0", "3");
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes()).reversed()
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
+    }
+
+    @Test
+    @DisplayName("정렬 - 인기 적은 순")
+    @Rollback(false)
+    void t012() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", "0", "4");
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes())
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
+    }
+
+    @Test
+    @DisplayName("정렬 - 성별순")
+    @Rollback(false)
+    void t013() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", "0", "5");
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getGender()).reversed()
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
+    }
+
+    @Test
+    @DisplayName("정렬 - 호감사유순")
+    @Rollback(false)
+    void t014() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", "0", "6");
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing(LikeablePerson::getAttractiveTypeCode)
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/notification/controller/NotificationControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/notification/controller/NotificationControllerTests.java
@@ -48,7 +48,7 @@ public class NotificationControllerTests {
                 .filter(notification -> !notification.isRead())
                 .count();
 
-        assertThat(unreadCount).isEqualTo(1);
+        assertThat(unreadCount).isEqualTo(7);
 
         // WHEN
         ResultActions resultActions = mvc


### PR DESCRIPTION
## Title: [4Week] 김민우

### 미션 요구사항 분석 & 체크리스트

필수미션
* [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
* [x] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용

<br>

선택미션 
* [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
* [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
  * [x] 최신순: 최근에 받은 호감부터 보여준다.
  * [x] 날짜순: 가장 오래전에 받은 호감부터 보여준다.
  * [x] 인기 많은 순서: 나에게 호감을 표하는 사람들의 인기를 기준으로 정렬한다.
  * [x] 인기 적은 순서: 나에게 호감을 표하는 사람들의 인기를 기준으로 정렬한다.
  * [x] 성별순: 여성부터 표기하고 그 다음에 남성 표기. 2순위 정렬조건은 최신
  * [x] 호감사유: 외모->성격->능력 순서로 리스트를 정렬한다.
* [x] 젠킨스를 통해서 repository 의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포되로고 하기.

### 4주차 미션 요약

---

**[접근 방법]**

1. 필터링 기능 + 정렬 기능
* stream 의 filter()를 이용해서 List<LikeablePerson> 을 gender, attractiveTypeCode 2개를 기준으로 필터링을 했다.
* 정렬 기능도 마찬가지로 stream 을 사용했다. stream 의 sorted() 와 정렬의 기준으로 세우는 Comparator.comparing()을 사용했다.
  * 정렬 기준이 2가지 이상인 경우에는 `Comparator.comparing(1차 정렬 조건).thenComparing(2차 정렬 조건)` 이렇게 사용했다.



**[특이사항]**
* stream 을 이용해서 정렬을 하였는데, 인기를 기준으로 정렬을 하는데 조금 어려웠다.
* likeablePerson.getFromInstaMember().getToLikeablePeople().size() 로 비교를 해야되는데 계속 에러가 발생했다.
* 에러의 원인은 chatGPT 에게 물어봤더니, getToLikeablePeople() or getFromInstaMember() 에게 null 을 반환할 수 있기 때문이였다.

**참고: [Refactoring]**
